### PR TITLE
Use cls-hooked instead of continuation-local-storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "7.6.0"
   - "8"
+  - "9"
+  - "9.5.0"
 install:
   - npm i
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4.4.7"
   - "6"
   - "7"
   - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "6"
-  - "7"
+  - "7.6.0"
   - "8"
 install:
   - npm i

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
 # Express HTTP Context
 Get and set request-scoped context anywhere.  This is just an unopinionated, idiomatic ExpressJS implementation of [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked) (forked from [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage)).  It's a great place to store user state, claims from a JWT, request/correlation IDs, and any other request-scoped data. Context is preserved even over async/await (in node 8+).
 
-(Note: For node v4-7, use the legacy 0.x.x package version.)
-
 ## How to use it
 
-Install: `npm install --save express-http-context`
+Install: `npm install --save express-http-context`  
+(Note: For node v4-7, use the legacy version: `npm install --save express-http-context@<1.0.0`)
 
 Use the middleware.  The earlier the better; you won't have access to the context from any middleware "used" before this one.
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
-[![travis](https://img.shields.io/travis/amiram/express-cls-hooked.svg)](https://travis-ci.org/amiram/express-cls-hooked)
-[![coveralls](https://img.shields.io/coveralls/amiram/express-cls-hooked.svg)](https://coveralls.io/github/amiram/express-cls-hooked)
-[![npm](https://img.shields.io/npm/v/express-cls-hooked.svg)](https://www.npmjs.com/package/express-cls-hooked)
-[![npm](https://img.shields.io/npm/dm/express-cls-hooked.svg)](https://www.npmjs.com/package/express-cls-hooked)
-[![david](https://img.shields.io/david/amiram/express-cls-hooked.svg)](https://david-dm.org/amiram/express-cls-hooked)
+[![travis](https://img.shields.io/travis/skonves/express-http-context.svg)](https://travis-ci.org/skonves/express-http-context)
+[![coveralls](https://img.shields.io/coveralls/skonves/express-http-context.svg)](https://coveralls.io/github/skonves/express-http-context)
+[![npm](https://img.shields.io/npm/v/express-http-context.svg)](https://www.npmjs.com/package/express-http-context)
+[![npm](https://img.shields.io/npm/dm/express-http-context.svg)](https://www.npmjs.com/package/express-http-context)
+[![david](https://img.shields.io/david/skonves/express-http-context.svg)](https://david-dm.org/skonves/express-http-context)
 
-# Express HTTP Context with async_hooks
+# Express HTTP Context
+Get and set request-scoped context anywhere.  This is just an unopinionated, idiomatic ExpressJS implementation of [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked) (forked from [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage)).  It's a great place to store user state, claims from a JWT, request/correlation IDs, and any other request-scoped data. Context is preserved even over async/await (in node 8+).
 
-**This package is forked from [express-http-context](https://github.com/skonves/express-http-context). It is using [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked) which is a fork of [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage) that uses async_hooks API, so context is preserved even over async/await in node 8+. If you're using node version < 8, just use the original [express-http-context](https://github.com/skonves/express-http-context).**  
-
-Get and set request-scoped context anywhere.  This is just an unopinionated, idiomatic ExpressJS implementation of [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage).  It's a great place to store user state, claims from a JWT, request/correlation IDs, and any other request-scoped data.
+(Note: For node v4-7, use the legacy 0.x.x package version.)
 
 ## How to use it
 
-Install: `npm install --save express-cls-hooked`
+Install: `npm install --save express-http-context`
 
 Use the middleware.  The earlier the better; you won't have access to the context from any middleware "used" before this one.
 
 ``` js
 var express = require('express');
-var httpContext = require('express-cls-hooked');
+var httpContext = require('express-http-context');
 
 var app = express();
 
@@ -45,7 +44,7 @@ app.use((req, res, next) => {
 Get them from code that doesn't have access to the express `req` object:
 
 ``` js
-var httpContext = require('express-cls-hooked');
+var httpContext = require('express-http-context');
 
 // Somewhere deep in the Todo Service
 function createTodoItem(title, content, callback) {
@@ -56,7 +55,7 @@ function createTodoItem(title, content, callback) {
 
 ## Troubleshooting
 To avoid weird behavior with express:
-1. Make sure you require `express-cls-hooked` in the first row of your app. Some popular packages use async which breaks CLS.
-1. If you are using `body-parser` and context is getting lost, register it in express before you register `express-cls-hooked`'s middleware.
+1. Make sure you require `express-http-context` in the first row of your app. Some popular packages use async which breaks CLS.
+1. If you are using `body-parser` and context is getting lost, register it in express before you register `express-http-context`'s middleware.
 
 See [Issue #4](https://github.com/skonves/express-http-context/issues/4) for more context.  If you find any other weird behaviors, please feel free to open an issue.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Express HTTP Context with async_hooks
 
-**This package is forked from [express-http-context](https://github.com/skonves/express-http-context). It is using [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked) which is a fork of [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage) that uses async_hooks API, so context is preserved even over async/await in node 8+.**  
+**This package is forked from [express-http-context](https://github.com/skonves/express-http-context). It is using [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked) which is a fork of [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage) that uses async_hooks API, so context is preserved even over async/await in node 8+. If you're using node version < 8, just use the original [express-http-context](https://github.com/skonves/express-http-context).**  
 
 Get and set request-scoped context anywhere.  This is just an unopinionated, idiomatic ExpressJS implementation of [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage).  It's a great place to store user state, claims from a JWT, request/correlation IDs, and any other request-scoped data.
 

--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ To avoid weird behavior with express:
 1. If you are using `body-parser` and context is getting lost, register it in express before you register `express-http-context`'s middleware.
 
 See [Issue #4](https://github.com/skonves/express-http-context/issues/4) for more context.  If you find any other weird behaviors, please feel free to open an issue.
+
+## Contributors
+Steve Konves (@skonves)
+Amiram Korach (@amiram)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
-[![travis](https://img.shields.io/travis/skonves/express-http-context.svg)](https://travis-ci.org/skonves/express-http-context)
-[![coveralls](https://img.shields.io/coveralls/skonves/express-http-context.svg)](https://coveralls.io/github/skonves/express-http-context)
-[![npm](https://img.shields.io/npm/v/express-http-context.svg)](https://www.npmjs.com/package/express-http-context)
-[![npm](https://img.shields.io/npm/dm/express-http-context.svg)](https://www.npmjs.com/package/express-http-context)
-[![david](https://img.shields.io/david/skonves/express-http-context.svg)](https://david-dm.org/skonves/express-http-context)
+[![travis](https://img.shields.io/travis/amiram/express-cls-hooked.svg)](https://travis-ci.org/amiram/express-cls-hooked)
+[![coveralls](https://img.shields.io/coveralls/amiram/express-cls-hooked.svg)](https://coveralls.io/github/amiram/express-cls-hooked)
+[![npm](https://img.shields.io/npm/v/express-cls-hooked.svg)](https://www.npmjs.com/package/express-cls-hooked)
+[![npm](https://img.shields.io/npm/dm/express-cls-hooked.svg)](https://www.npmjs.com/package/express-cls-hooked)
+[![david](https://img.shields.io/david/amiram/express-cls-hooked.svg)](https://david-dm.org/amiram/express-cls-hooked)
 
-# Express HTTP Context
+# Express HTTP Context with async_hooks
+
+**This package is forked from [express-http-context](https://github.com/skonves/express-http-context). It is using [cls-hooked](https://github.com/Jeff-Lewis/cls-hooked) which is a fork of [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage) that uses async_hooks API, so context is preserved even over async/await in node 8+.**  
+
 Get and set request-scoped context anywhere.  This is just an unopinionated, idiomatic ExpressJS implementation of [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage).  It's a great place to store user state, claims from a JWT, request/correlation IDs, and any other request-scoped data.
 
 ## How to use it
 
-Install: `npm install --save express-http-context`
+Install: `npm install --save express-cls-hooked`
 
 Use the middleware.  The earlier the better; you won't have access to the context from any middleware "used" before this one.
 
 ``` js
 var express = require('express');
-var httpContext = require('express-http-context');
+var httpContext = require('express-cls-hooked');
 
 var app = express();
 
@@ -42,7 +45,7 @@ app.use((req, res, next) => {
 Get them from code that doesn't have access to the express `req` object:
 
 ``` js
-var httpContext = require('express-http-context');
+var httpContext = require('express-cls-hooked');
 
 // Somewhere deep in the Todo Service
 function createTodoItem(title, content, callback) {
@@ -53,7 +56,7 @@ function createTodoItem(title, content, callback) {
 
 ## Troubleshooting
 To avoid weird behavior with express:
-1. Make sure you require `express-http-context` in the first row of your app. Some popular packages use async which breaks CLS.
-1. If you are using `body-parser` and context is getting lost, register it in express before you register `express-http-context`'s middleware.
+1. Make sure you require `express-cls-hooked` in the first row of your app. Some popular packages use async which breaks CLS.
+1. If you are using `body-parser` and context is getting lost, register it in express before you register `express-cls-hooked`'s middleware.
 
 See [Issue #4](https://github.com/skonves/express-http-context/issues/4) for more context.  If you find any other weird behaviors, please feel free to open an issue.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 
 const nsid = 'a6a29a6f-6747-4b5f-b99f-07ee96e32f88';
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-http-context",
+  "name": "express-cls-hooked",
   "version": "0.3.4",
   "description": "Get and set request-scoped context anywhere",
   "main": "index.js",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/skonves/express-http-context.git"
+    "url": "git+https://github.com/amiram/express-cls-hooked.git"
   },
   "keywords": [
     "express",
@@ -21,9 +21,9 @@
   "author": "Steve Konves",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/skonves/express-http-context/issues"
+    "url": "https://github.com/amiram/express-cls-hooked/issues"
   },
-  "homepage": "https://github.com/skonves/express-http-context#readme",
+  "homepage": "https://github.com/amiram/express-cls-hooked#readme",
   "dependencies": {
     "cls-hooked": "^4.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "express-cls-hooked",
-  "version": "0.3.8",
+  "name": "express-http-context",
+  "version": "0.3.4",
   "description": "Get and set request-scoped context anywhere",
   "main": "index.js",
   "engines": {
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/amiram/express-cls-hooked.git"
+    "url": "git+https://github.com/skonves/express-http-context.git"
   },
   "keywords": [
     "express",
@@ -24,9 +24,9 @@
   "author": "Steve Konves (Amiram Korach)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/amiram/express-cls-hooked/issues"
+    "url": "https://github.com/skonves/express-http-context/issues"
   },
-  "homepage": "https://github.com/amiram/express-cls-hooked#readme",
+  "homepage": "https://github.com/skonves/express-http-context#readme",
   "dependencies": {
     "cls-hooked": "^4.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-cls-hooked",
-  "version": "0.0.1",
+  "version": "0.3.6",
   "description": "Get and set request-scoped context anywhere",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/skonves/express-http-context#readme",
   "dependencies": {
-    "continuation-local-storage": "^3.2.0"
+    "cls-hooked": "^4.2.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-cls-hooked",
-  "version": "0.3.6",
+  "version": "0.3.8",
   "description": "Get and set request-scoped context anywhere",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cls-hooked": "^4.2.2"
   },
   "devDependencies": {
+    "bluebird": "^3.5.1",
     "chai": "^3.5.0",
     "coveralls": "^2.13.0",
     "express": "^4.15.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-cls-hooked",
-  "version": "0.3.4",
+  "version": "0.0.1",
   "description": "Get and set request-scoped context anywhere",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "request",
     "context"
   ],
-  "author": "Steve Konves",
+  "author": "Steve Konves (Amiram Korach)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/amiram/express-cls-hooked/issues"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.6",
   "description": "Get and set request-scoped context anywhere",
   "main": "index.js",
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "scripts": {
     "cover": "istanbul cover _mocha index.js -R ./tests --coverage",
     "test": "mocha ./tests",
@@ -29,11 +32,11 @@
   },
   "devDependencies": {
     "bluebird": "^3.5.1",
-    "chai": "^3.5.0",
-    "coveralls": "^2.13.0",
-    "express": "^4.15.2",
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "express": "^4.16.2",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
+    "mocha": "^5.0.1",
     "mocha-lcov-reporter": "^1.3.0",
     "supertest": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "request",
     "context"
   ],
-  "author": "Steve Konves (Amiram Korach)",
+  "author": "Steve Konves",
+  "contributors": [
+    "Steve Konves",
+    "Amiram Korach"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/skonves/express-http-context/issues"

--- a/tests/express-test-harness.js
+++ b/tests/express-test-harness.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const express = require('express');
 const supertest = require('supertest');
+const bluebird = require('bluebird');
 
 const httpContext = require('../index');
 
@@ -57,7 +58,48 @@ describe('express-cls-hooked', function () {
 		});
 	});
 
-	it('returns undefined when key is not found', function (done) {
+  it('maintains unique value across concurrent requests with async/await', function (done) {
+    // ARRANGE
+    const app = express();
+
+    app.use(httpContext.middleware);
+
+    app.get('/test', (req, res) => {
+      const delay = new Number(req.query.delay);
+      const valueFromRequest = req.query.value;
+
+      httpContext.set('value', valueFromRequest);
+
+      const doJob = async () => {
+        await bluebird.delay(delay);
+        const valueFromContext = httpContext.get('value');
+        res.status(200).json({
+          value: valueFromContext
+        });
+      };
+
+      doJob();
+    });
+
+    const sut = supertest(app);
+
+    const value1 = 'value1';
+    const value2 = 'value2';
+
+    // ACT
+    sut.get('/test').query({ delay: 100, value: value1 }).end((err, res) => {
+      // ASSERT
+      assert.equal(res.body.value, value1);
+      done();
+    });
+
+    sut.get('/test').query({ delay: 50, value: value2 }).end((err, res) => {
+      // ASSERT
+      assert.equal(res.body.value, value2);
+    });
+  });
+
+  it('returns undefined when key is not found', function (done) {
 		// ARRANGE
 		const app = express();
 

--- a/tests/express-test-harness.js
+++ b/tests/express-test-harness.js
@@ -7,7 +7,7 @@ const bluebird = require('bluebird');
 
 const httpContext = require('../index');
 
-describe('express-cls-hooked', function () {
+describe('express-http-context', function () {
 	it('does not store or return context outside of request', function () {
 		// ARRANGE
 		const key = 'key';

--- a/tests/express-test-harness.js
+++ b/tests/express-test-harness.js
@@ -6,7 +6,7 @@ const supertest = require('supertest');
 
 const httpContext = require('../index');
 
-describe('express-http-context', function () {
+describe('express-cls-hooked', function () {
 	it('does not store or return context outside of request', function () {
 		// ARRANGE
 		const key = 'key';


### PR DESCRIPTION
This introduces a Node version restriction of 8+.  All maintenance for Node v4-7 will happen on the diverged "legacy" branch.

closes #3 