### PR TITLE
Expose namespace to allow apply patches to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ function createTodoItem(title, content, callback) {
 }
 ```
 
+You can access cls namespace directly as (it may be useful if you want to apply some patch to it, for example https://github.com/TimBeyer/cls-bluebird):
+``` js
+var ns = require('express-http-context').ns;
+```
+
 ## Troubleshooting
 To avoid weird behavior with express:
 1. Make sure you require `express-http-context` in the first row of your app. Some popular packages use async which breaks CLS.

--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@
 const cls = require('cls-hooked');
 
 const nsid = 'a6a29a6f-6747-4b5f-b99f-07ee96e32f88';
+const ns = cls.createNamespace(nsid);
 
 /** Express.js middleware that is responsible for initializing the context for each request. */
 function middleware(req, res, next) {
-	const ns = cls.getNamespace(nsid) || cls.createNamespace(nsid);
 	ns.run(() => next());
 }
 
@@ -15,7 +15,6 @@ function middleware(req, res, next) {
  * @param {string} key
  */
 function get(key) {
-	const ns = cls.getNamespace(nsid);
 	if (ns && ns.active) {
 		return ns.get(key);
 	}
@@ -27,7 +26,6 @@ function get(key) {
  * @param {*} value 
  */
 function set(key, value) {
-	const ns = cls.getNamespace(nsid);
 	if (ns && ns.active) {
 		return ns.set(key, value);
 	}
@@ -36,5 +34,6 @@ function set(key, value) {
 module.exports = {
 	middleware,
 	get: get,
-	set: set
-}
+	set: set,
+	ns: ns
+};


### PR DESCRIPTION
cls-hooked do not work out of box with bluebird (https://github.com/Jeff-Lewis/cls-hooked/issues/16)
Suggested solution is to use (https://github.com/TimBeyer/cls-bluebird) that require access to namespace. 
So this change allow to patch namespace that was internally created by express-http-context