### PR TITLE
fix: add cls-hooked types as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "homepage": "https://github.com/skonves/express-http-context#readme",
   "dependencies": {
     "@types/cls-hooked": "^4.2.1",
+    "@types/express": "^4.16.0",
     "cls-hooked": "^4.2.2"
   },
   "devDependencies": {
-    "@types/express": "^4.16.0",
     "chai": "^4.1.2",
     "coveralls": "^3.0.1",
     "express": "^4.16.2",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   },
   "homepage": "https://github.com/skonves/express-http-context#readme",
   "dependencies": {
+    "@types/cls-hooked": "^4.2.1",
     "cls-hooked": "^4.2.2"
   },
   "devDependencies": {
-    "@types/cls-hooked": "^4.2.1",
     "@types/express": "^4.16.0",
     "chai": "^4.1.2",
     "coveralls": "^3.0.1",


### PR DESCRIPTION
To fix this:

![image](https://user-images.githubusercontent.com/1404810/56651417-45da5500-6689-11e9-89c1-d3e6d3371b7c.png)

While I did not get an express type error, that's because I had it installed myself (which I suppose most people have if using this module and TS). However, it's still preferable to include all used dependencies

https://github.com/skonves/express-http-context/blob/26a22eb04795f9c2d52807208381635d66010ae8/index.d.ts#L1