### PR TITLE
Fixes #48 - assumes an ES5 target in browser facing code

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,11 +1,11 @@
 module.exports = {
-  middleware: (req, res, next) => {
+  middleware: function (req, res, next) {
     throw new Error('`middleware` cannot be called from the browser code.');
   },
-  get: (key) => {
+  get: function () {
     return null;
   },
-  set: (key, value) => {
+  set: function (key, value) {
     // noop
   },
   ns: null,


### PR DESCRIPTION
Uses ES5 function syntax in place of arrow functions.